### PR TITLE
Bubbles do not resize when user zooms the chart

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -83,7 +83,7 @@ public class BubbleChartRenderer extends BarLineScatterCandleBubbleRenderer {
         // calcualte the full width of 1 step on the x-axis
         final float maxBubbleWidth = Math.abs(sizeBuffer[2] - sizeBuffer[0]);
         final float maxBubbleHeight = Math.abs(mViewPortHandler.contentBottom() - mViewPortHandler.contentTop());
-        final float referenceSize = Math.min(maxBubbleHeight, maxBubbleWidth);
+        final float referenceSize = 100;//Math.min(maxBubbleHeight, maxBubbleWidth);
 
         for (int j = mXBounds.min; j <= mXBounds.range + mXBounds.min; j++) {
 
@@ -233,7 +233,7 @@ public class BubbleChartRenderer extends BarLineScatterCandleBubbleRenderer {
             final float maxBubbleWidth = Math.abs(sizeBuffer[2] - sizeBuffer[0]);
             final float maxBubbleHeight = Math.abs(
                     mViewPortHandler.contentBottom() - mViewPortHandler.contentTop());
-            final float referenceSize = Math.min(maxBubbleHeight, maxBubbleWidth);
+            final float referenceSize = 100;//Math.min(maxBubbleHeight, maxBubbleWidth);
 
             pointBuffer[0] = entry.getX();
             pointBuffer[1] = (entry.getY()) * phaseY;


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Makes bubbles size static after they are rendered on Bubble chart. Zooming in no longer increasez their size
<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
